### PR TITLE
fix scrollbar drag bug

### DIFF
--- a/haxe/ui/backend/ComponentImpl.hx
+++ b/haxe/ui/backend/ComponentImpl.hx
@@ -95,11 +95,11 @@ class ComponentImpl extends ComponentBase {
 
 				visual.width = background.width = width;
 				visual.height = background.height = height;
+				if (style != null) {
+					applyStyle(style);
+				}
 		}
 
-		if (style != null) {
-			applyStyle(style);
-		}
 		
 		// trace('${pad(this.id)}: size -> ${width}x${height}');
 	}


### PR DESCRIPTION
Fixes the problem with scrollbars not dragging due to components width and height being set to the style's default width and height before a hitTest was performed.

I tested this in my own app being developed and have not seen any issues due to this change.