### PR TITLE
Fix TreeViewNode expand icon not expanding

### DIFF
--- a/haxe/ui/backend/ComponentImpl.hx
+++ b/haxe/ui/backend/ComponentImpl.hx
@@ -374,13 +374,17 @@ class ComponentImpl extends ComponentBase {
 
 
 	private function hasComponentOver(ref:Component, x:Float, y:Float, reverse:Bool = false):Bool {
-		var array:Array<Component> = getComponentsAtPoint(x, y, reverse);
+		var array:Array<Component> = getVisibleComponentsAtPoint(x, y, reverse);
 		if (array.length == 0) {
-			return false;
+      return false;
 		}
 
 		return !hasChildRecursive(cast ref, cast array[array.length - 1]);
 	}
+
+  private function getVisibleComponentsAtPoint(x:Float, y:Float, reverse:Bool) {
+		return getComponentsAtPoint(x, y, reverse).filter(c -> c.hidden == false);
+  }
 
 	private function getComponentsAtPoint(x:Float, y:Float,
 			reverse:Bool = false):Array<Component> {

--- a/haxe/ui/backend/ComponentImpl.hx
+++ b/haxe/ui/backend/ComponentImpl.hx
@@ -376,15 +376,15 @@ class ComponentImpl extends ComponentBase {
 	private function hasComponentOver(ref:Component, x:Float, y:Float, reverse:Bool = false):Bool {
 		var array:Array<Component> = getVisibleComponentsAtPoint(x, y, reverse);
 		if (array.length == 0) {
-      return false;
+			return false;
 		}
 
 		return !hasChildRecursive(cast ref, cast array[array.length - 1]);
 	}
 
-  private function getVisibleComponentsAtPoint(x:Float, y:Float, reverse:Bool) {
+	private function getVisibleComponentsAtPoint(x:Float, y:Float, reverse:Bool) {
 		return getComponentsAtPoint(x, y, reverse).filter(c -> c.hidden == false);
-  }
+	}
 
 	private function getComponentsAtPoint(x:Float, y:Float,
 			reverse:Bool = false):Array<Component> {


### PR DESCRIPTION
Fixes the issue we had wit the icon for TreeViewNodes not expanding when clicked, the problem is that there is a hidden container that causes `hasComponentOver` to always return true, my solution is to filter out any components that are hidden. I made a new function that uses the `getComponentsAtPoint` so I don't  interfere with any possible future uses of that function.