### PR TITLE
Create define to configure the factor that fonts are multipled by while prerendered

### DIFF
--- a/haxe/ui/backend/TextDisplayImpl.hx
+++ b/haxe/ui/backend/TextDisplayImpl.hx
@@ -48,11 +48,11 @@ class TextDisplayImpl extends TextBase {
 
 			if (_textStyle.fontSize != null) {
 				/**
-				 * Before creating text, we prerender the fonts a couple sizes larger
-				 * You can set how much larger with the -D prerender_font_offset
-				 * By default it is 8
+				 * Before creating text, we prerender the fonts larger than the expectd output
+				 * You can set how much larger with the -D prerender_font_factor
+				 * By default it is 2x
 				 */
-				visual.preRenderedSize = Std.int(_textStyle.fontSize) + ceramic.macros.DefinesMacro.getIntDefine("prerender_font_offset") ?? 8;
+				visual.preRenderedSize = Std.int(_textStyle.fontSize) * ceramic.macros.DefinesMacro.getIntDefine("prerender_font_factor") ?? 2;
 				visual.pointSize = Std.int(_textStyle.fontSize);
 				measureTextRequired = true;
 			}

--- a/haxe/ui/backend/TextDisplayImpl.hx
+++ b/haxe/ui/backend/TextDisplayImpl.hx
@@ -47,7 +47,12 @@ class TextDisplayImpl extends TextBase {
 			}
 
 			if (_textStyle.fontSize != null) {
-				visual.preRenderedSize = Std.int(_textStyle.fontSize) + 4;
+				/**
+				 * Before creating text, we prerender the fonts a couple sizes larger
+				 * You can set how much larger with the -D prerender_font_offset
+				 * By default it is 8
+				 */
+				visual.preRenderedSize = Std.int(_textStyle.fontSize) + ceramic.macros.DefinesMacro.getIntDefine("prerender_font_offset") ?? 8;
 				visual.pointSize = Std.int(_textStyle.fontSize);
 				measureTextRequired = true;
 			}


### PR DESCRIPTION
I found increasing this makes the text a little nicer. I tried applying roundTranslation to the visual but it doesn't look as good. It would be a better solution if we were dealing with pixel perfect fonts. Some more work needs to be done in text-land.