### PR TITLE
fix rendering of root filter when resizing beyond original dimensions

### DIFF
--- a/haxe/ui/backend/Ceramic.hx
+++ b/haxe/ui/backend/Ceramic.hx
@@ -46,6 +46,8 @@ class Ceramic {
 			return;
 		}
 
+		internal_options().root.bindToNativeScreenSize();
+
 		if (!draw) {
 			internal_options().root.render();
 		}


### PR DESCRIPTION
This is the workaround I found that solves the issue when resizing an app that caused anything outside the original dimensions to render as black.